### PR TITLE
Rewrite ISO layout: full JP DSIs with auto-sized blocks

### DIFF
--- a/lib/cddata.py
+++ b/lib/cddata.py
@@ -19,7 +19,7 @@ import shutil
 import subprocess
 import tempfile
 
-from .constants import SECTOR_SIZE, SCEI_BANK_MAP, USA_TABLE_OFFSET, JP_TABLE_OFFSET, TABLE_ENTRY_COUNT
+from .constants import SECTOR, SCEI_BANK_MAP, USA_TABLE_OFFSET, JP_TABLE_OFFSET, TABLE_ENTRY_COUNT
 
 from racjin import compress as racjin_compress, decompress as racjin_decompress
 
@@ -267,7 +267,7 @@ def build_mapping(usa_iso, jp_iso):
         info = find_file_in_iso(iso, search)
         if info:
             sec, sz, _ = info
-            exe = iso[sec * SECTOR_SIZE:sec * SECTOR_SIZE + sz]
+            exe = iso[sec * SECTOR:sec * SECTOR + sz]
             if target == 'usa':
                 usa_exe = exe
             else:
@@ -336,10 +336,10 @@ def patch_cddata(usa_dig, jp_dig, mapping):
         if jp_sector == 0 or jp_comp_size == 0:
             continue
 
-        jp_raw = jp_dig[jp_sector * SECTOR_SIZE:jp_sector * SECTOR_SIZE + jp_comp_size]
-        usa_raw = out[usa_sector * SECTOR_SIZE:usa_sector * SECTOR_SIZE + usa_comp_size]
+        jp_raw = jp_dig[jp_sector * SECTOR:jp_sector * SECTOR + jp_comp_size]
+        usa_raw = out[usa_sector * SECTOR:usa_sector * SECTOR + usa_comp_size]
         slot_size = usa_comp_size
-        data_offset = usa_sector * SECTOR_SIZE
+        data_offset = usa_sector * SECTOR
 
         # 1. Skip identical entries (shared SFX/music)
         if jp_raw == usa_raw:

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -14,7 +14,7 @@ VIDEO_TYPE_TAG = -16384      # 0xFFFFC000 — identifies video stream in block h
 # ISO / CDDATA
 # =============================================================================
 
-SECTOR_SIZE = 2048           # ISO9660 sector size
+SECTOR = 2048           # ISO9660 sector size
 
 # Offsets into game executables where the CDDATA entry lookup tables live
 USA_TABLE_OFFSET = 0x1B612E  # in SLUS_209.94

--- a/lib/ffmpeg.py
+++ b/lib/ffmpeg.py
@@ -35,7 +35,7 @@ def find_or_build_ffmpeg():
     for path in candidates:
         if path and os.path.exists(path):
             r = subprocess.run([path, '-filters'], capture_output=True, text=True)
-            if 'subtitles' in r.stdout:
+            if 'subtitles' in r.stdout or 'libass' in r.stdout:
                 return path
 
     # Need to build ffmpeg with libass

--- a/lib/iso.py
+++ b/lib/iso.py
@@ -36,6 +36,23 @@ def find_file_in_iso(iso_data, filename):
     return sector, size, entry
 
 
+def update_dir_entry(f, entry_offset, sector, size):
+    """Update an ISO9660 directory entry's sector and size (both LE and BE).
+
+    Args:
+        f: File object opened in r+b mode.
+        entry_offset: Byte offset of the directory entry in the ISO.
+        sector: New starting sector.
+        size: New file size in bytes.
+    """
+    f.seek(entry_offset + 2)
+    f.write(struct.pack('<I', sector))
+    f.write(struct.pack('>I', sector))
+    f.seek(entry_offset + 10)
+    f.write(struct.pack('<I', size))
+    f.write(struct.pack('>I', size))
+
+
 def verify_iso(path, label, expected, skip=False):
     """Verify an ISO file's size and MD5 hash.
 

--- a/lib/iso.py
+++ b/lib/iso.py
@@ -9,7 +9,7 @@ import struct
 import os
 import hashlib
 
-from .constants import SECTOR_SIZE
+from .constants import SECTOR
 
 
 def find_file_in_iso(iso_data, filename):
@@ -73,8 +73,11 @@ def verify_iso(path, label, expected, skip=False):
         return True
 
     print(f"  Verifying {label}...", end=' ', flush=True)
+    md5_hash = hashlib.md5()
     with open(path, 'rb') as f:
-        md5 = hashlib.md5(f.read()).hexdigest()
+        while chunk := f.read(64 * 1024 * 1024):
+            md5_hash.update(chunk)
+    md5 = md5_hash.hexdigest()
     if md5 == expected['md5']:
         print("OK")
         return True

--- a/lib/video.py
+++ b/lib/video.py
@@ -3,26 +3,17 @@ Video encoding and DSI muxing for subtitled cutscenes.
 
 This module handles:
 1. MPEG-2 encoding with burned ASS subtitles
-2. Proportional audio DSI muxing (the key algorithm for A/V sync)
+2. DSI muxing via dsi-muxer
 3. MKV export with squeezed JP audio
-
-The proportional audio algorithm distributes audio per block based on
-the number of video frames in that block. This ensures each block's
-audio duration matches its video duration, producing perfect A/V sync
-on PS2 hardware regardless of the video encoder used.
 """
 
-import struct
 import os
 import shutil
 import subprocess
 
 import tempfile
 
-from .constants import DSI_BLOCK_SIZE, AUDIO_TYPE_TAG, VIDEO_TYPE_TAG
-
 from dsi_muxer import DSI
-from dsi_muxer.container import _count_markers
 
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -39,11 +30,6 @@ def _find_fontsdir():
         if os.path.isdir(d):
             return d
     return None
-
-
-def _count_pics(data):
-    """Count MPEG-2 picture start codes (00 00 01 00) in video data."""
-    return _count_markers(data, b'\x00\x00\x01\x00')
 
 
 # =============================================================================
@@ -131,161 +117,6 @@ def build_subtitled_dsi(ffmpeg_bin, jp_dsi_bytes, ass_path):
 
     new_dsi = DSI.mux(new_video, audio)
     return new_dsi.to_bytes()
-
-
-# =============================================================================
-# DSI Muxer — Proportional Audio Algorithm (legacy)
-# =============================================================================
-
-def mux_dsi_proportional(video_data, audio_data, nblocks):
-    """Mux video + audio into DSI blocks with proportional audio.
-
-    THE KEY ALGORITHM: Each block gets audio proportional to its video
-    frame count. This ensures audio duration ≈ video duration per block,
-    producing perfect A/V sync on PS2 hardware.
-
-    The video is byte-sliced as a continuous stream — GOPs flow freely
-    across block boundaries, exactly like the original game files.
-
-    Last block uses the original's V→A structure with end-of-sequence.
-
-    Args:
-        video_data: MPEG-2 elementary stream (with end-of-sequence).
-        audio_data: PS2 SPU ADPCM audio stream.
-        nblocks: Number of DSI blocks to create.
-
-    Returns:
-        Complete DSI file as bytes.
-    """
-    usable = DSI_BLOCK_SIZE - 64  # bytes available per block (after header)
-    total_frames = _count_pics(video_data)
-    audio_per_frame = len(audio_data) / total_frames if total_frames > 0 else 512
-
-    out = bytearray(nblocks * DSI_BLOCK_SIZE)
-    vid_pos = 0
-    aud_pos = 0
-
-    for blk in range(nblocks):
-        base = blk * DSI_BLOCK_SIZE
-        is_last = (blk == nblocks - 1)
-
-        if is_last:
-            # Last block matches original structure: V→A, small sizes, slack
-            aud_sz = 5120
-            vid_cap = 65472
-        else:
-            # Estimate frames in this block's byte range
-            est_aud = max(512, (round(8 * audio_per_frame) // 512) * 512)
-            est_vid_cap = usable - est_aud
-            chunk = video_data[vid_pos:vid_pos + est_vid_cap] if vid_pos < len(video_data) else b''
-            actual_frames = _count_pics(chunk)
-
-            # Audio proportional to frame count
-            aud_sz = max(512, (round(actual_frames * audio_per_frame) // 512) * 512)
-            vid_cap = usable - aud_sz
-
-        # Byte-slice video from continuous stream
-        vc = video_data[vid_pos:vid_pos + vid_cap] if vid_pos < len(video_data) else b''
-        if len(vc) < vid_cap:
-            vc += b'\x00' * (vid_cap - len(vc))
-
-        # Audio chunk
-        ac = audio_data[aud_pos:aud_pos + aud_sz]
-        if len(ac) < aud_sz:
-            ac += b'\x00' * (aud_sz - len(ac))
-
-        # Write block header + data
-        if is_last:
-            # V→A order for last block (matches original)
-            struct.pack_into('<IIiIIiII', out, base,
-                2, 64, VIDEO_TYPE_TAG, vid_cap,
-                64 + vid_cap, AUDIO_TYPE_TAG, aud_sz, 0)
-            out[base + 32:base + 64] = b'\x00' * 32
-            out[base + 64:base + 64 + vid_cap] = bytes(vc)[:vid_cap]
-            out[base + 64 + vid_cap:base + 64 + vid_cap + aud_sz] = ac[:aud_sz]
-        else:
-            # A→V order for normal blocks
-            struct.pack_into('<IIiIIiII', out, base,
-                2, 64, AUDIO_TYPE_TAG, aud_sz,
-                64 + aud_sz, VIDEO_TYPE_TAG, vid_cap, 0)
-            out[base + 32:base + 64] = b'\x00' * 32
-            out[base + 64:base + 64 + aud_sz] = ac
-            out[base + 64 + aud_sz:base + 64 + aud_sz + vid_cap] = bytes(vc)[:vid_cap]
-
-        vid_pos += vid_cap
-        aud_pos += aud_sz
-
-    # Post-process: ensure end-of-sequence marker exists in the last block
-    # with video data. Without this, the game won't transition after the cutscene.
-    end_marker = b'\x00\x00\x01\xb7'
-    for blk in range(nblocks - 1, -1, -1):
-        base = blk * DSI_BLOCK_SIZE
-        hdr = struct.unpack('<IIiIIiII', out[base:base + 32])
-        if hdr[2] == VIDEO_TYPE_TAG:
-            v_off, v_sz = base + hdr[1], hdr[3]
-        else:
-            v_off, v_sz = base + hdr[4], hdr[6]
-        region = out[v_off:v_off + v_sz]
-        if end_marker in region:
-            break  # already has one
-        # Find last nonzero byte and inject marker
-        last_nz = v_sz - 1
-        while last_nz > 0 and region[last_nz] == 0:
-            last_nz -= 1
-        if last_nz > 0 and last_nz + 5 < v_sz:
-            out[v_off + last_nz + 1:v_off + last_nz + 5] = end_marker
-            break
-
-    return bytes(out)
-
-
-# =============================================================================
-# DSI Stream Extraction (for audio-only mode)
-# =============================================================================
-
-def extract_dsi_audio(dsi_data):
-    """Extract the continuous audio stream from a DSI file."""
-    chunks = []
-    for blk in range(len(dsi_data) // DSI_BLOCK_SIZE):
-        base = blk * DSI_BLOCK_SIZE
-        hdr = struct.unpack('<IIiIIiII', dsi_data[base:base + 32])
-        if hdr[2] == AUDIO_TYPE_TAG:
-            chunks.append(dsi_data[base + hdr[1]:base + hdr[1] + hdr[3]])
-        else:
-            chunks.append(dsi_data[base + hdr[4]:base + hdr[4] + hdr[6]])
-    return b''.join(chunks)
-
-
-def extract_dsi_video(dsi_data):
-    """Extract the continuous video stream from a DSI file."""
-    chunks = []
-    for blk in range(len(dsi_data) // DSI_BLOCK_SIZE):
-        base = blk * DSI_BLOCK_SIZE
-        hdr = struct.unpack('<IIiIIiII', dsi_data[base:base + 32])
-        if hdr[2] == VIDEO_TYPE_TAG:
-            chunks.append(dsi_data[base + hdr[1]:base + hdr[1] + hdr[3]])
-        else:
-            chunks.append(dsi_data[base + hdr[4]:base + hdr[4] + hdr[6]])
-    return b''.join(chunks)
-
-
-def patch_dsi_audio(usa_dsi, jp_audio):
-    """Replace audio in a USA DSI with JP audio (preserves block structure)."""
-    out = bytearray(usa_dsi)
-    pos = 0
-    for blk in range(len(out) // DSI_BLOCK_SIZE):
-        base = blk * DSI_BLOCK_SIZE
-        hdr = struct.unpack('<IIiIIiII', out[base:base + 32])
-        if hdr[2] == AUDIO_TYPE_TAG:
-            a_off, a_sz = base + hdr[1], hdr[3]
-        else:
-            a_off, a_sz = base + hdr[4], hdr[6]
-        chunk = jp_audio[pos:pos + a_sz]
-        if len(chunk) < a_sz:
-            chunk += b'\x00' * (a_sz - len(chunk))
-        out[a_off:a_off + a_sz] = chunk
-        pos += a_sz
-    return bytes(out)
 
 
 # =============================================================================

--- a/lib/video.py
+++ b/lib/video.py
@@ -17,8 +17,11 @@ import os
 import shutil
 import subprocess
 
+import tempfile
+
 from .constants import DSI_BLOCK_SIZE, AUDIO_TYPE_TAG, VIDEO_TYPE_TAG
 
+from dsi_muxer import DSI
 from dsi_muxer.container import _count_markers
 
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -47,56 +50,30 @@ def _count_pics(data):
 # MPEG-2 Encoding
 # =============================================================================
 
-def encode_subtitled_video(ffmpeg_bin, m2v_path, ass_path, output_path, nblocks, total_audio):
+def encode_subtitled_video(ffmpeg_bin, m2v_path, ass_path, output_path):
     """Encode video with burned ASS subtitles as PS2-compatible MPEG-2.
 
-    Calculates the optimal bitrate to maximize DSI block utilization:
-    higher bitrate = more blocks filled with video = better quality.
-
-    Encoding parameters match the original TMPGEnc output:
-    - IBBP GOP structure, closed GOPs, 9-bit DC precision
-    - Non-linear quantizer, alternate intra VLC table
-    - NTSC color metadata, SAR 7:6 for 4:3 display
+    Uses high-quality CBR encoding at 7000k — no size constraint since
+    DSI block count is auto-calculated from content size.
 
     Args:
         ffmpeg_bin: Path to ffmpeg binary.
-        m2v_path: Input MPEG-2 video (USA original).
+        m2v_path: Input MPEG-2 video.
         ass_path: ASS subtitle file to burn.
         output_path: Where to write the encoded .m2v.
-        nblocks: Number of DSI blocks (determines bitrate target).
-        total_audio: Total audio bytes (determines per-block audio budget).
 
     Returns:
         True on success, False on failure.
     """
-    # Get frame count and duration from source
-    ffprobe = os.path.join(os.path.dirname(ffmpeg_bin), 'ffprobe')
-    if not os.path.exists(ffprobe):
-        ffprobe = shutil.which('ffprobe') or ffmpeg_bin
+    fontsdir = _find_fontsdir()
+    ass_filter = f'ass={ass_path}'
+    if fontsdir:
+        ass_filter += f':fontsdir={fontsdir}'
 
-    r = subprocess.run([ffprobe, '-v', 'error', '-count_frames', '-select_streams', 'v:0',
-        '-show_entries', 'stream=nb_read_frames,r_frame_rate',
-        '-of', 'csv=p=0', m2v_path], capture_output=True, text=True, timeout=120)
-    parts = r.stdout.strip().split(',')
-    if len(parts) < 2:
-        return False
-
-    num, den = parts[0].split('/')
-    fps = int(num) / int(den)
-    frames = int(parts[1])
-    duration = frames / fps
-
-    # Calculate optimal bitrate to fill blocks
-    avg_audio_per_block = total_audio // nblocks
-    avg_vid_capacity = (DSI_BLOCK_SIZE - 64) - avg_audio_per_block
-    target_bytes = nblocks * avg_vid_capacity
-    bitrate = int(target_bytes * 8 / duration / 1000)
-
-    # Encode with PS2-compatible MPEG-2 parameters
     subprocess.run([ffmpeg_bin, '-y', '-i', m2v_path,
-        '-vf', f'ass={ass_path}' + (f':fontsdir={_find_fontsdir()}' if _find_fontsdir() else '') + ',format=yuv420p',
+        '-vf', f'{ass_filter},format=yuv420p',
         '-c:v', 'mpeg2video',
-        '-b:v', f'{bitrate}k', '-minrate', f'{bitrate}k', '-maxrate', f'{bitrate}k',
+        '-b:v', '7000k', '-minrate', '7000k', '-maxrate', '7000k',
         '-bufsize', '1835008', '-qmin', '1', '-qmax', '12',
         '-s', '512x448', '-sar', '7:6', '-r', '30000/1001',
         '-g', '16', '-bf', '2', '-b_strategy', '0',
@@ -125,8 +102,39 @@ def encode_subtitled_video(ffmpeg_bin, m2v_path, ass_path, output_path, nblocks,
     return True
 
 
+def build_subtitled_dsi(ffmpeg_bin, jp_dsi_bytes, ass_path):
+    """Build a subtitled DSI from JP DSI bytes and an ASS subtitle file.
+
+    Pipeline:
+        1. Demux JP DSI -> video + audio
+        2. Burn subtitles onto video (MPEG-2 re-encode)
+        3. Remux with dsi-muxer (auto block count)
+
+    Returns DSI bytes, or None on failure.
+    """
+    dsi = DSI.from_bytes(jp_dsi_bytes)
+    video = dsi.extract_video()
+    audio = dsi.extract_audio()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        m2v_in = os.path.join(tmp, 'input.m2v')
+        m2v_out = os.path.join(tmp, 'output.m2v')
+
+        with open(m2v_in, 'wb') as f:
+            f.write(video)
+
+        if not encode_subtitled_video(ffmpeg_bin, m2v_in, ass_path, m2v_out):
+            return None
+
+        with open(m2v_out, 'rb') as f:
+            new_video = f.read()
+
+    new_dsi = DSI.mux(new_video, audio)
+    return new_dsi.to_bytes()
+
+
 # =============================================================================
-# DSI Muxer — Proportional Audio Algorithm
+# DSI Muxer — Proportional Audio Algorithm (legacy)
 # =============================================================================
 
 def mux_dsi_proportional(video_data, audio_data, nblocks):

--- a/patch.py
+++ b/patch.py
@@ -31,12 +31,9 @@ from lib.constants import (
     DSI_BLOCK_SIZE, SECTOR_SIZE, EXPECTED_HASHES,
     DSI_NAMES, SUBS_DIR,
 )
-from lib.iso import find_file_in_iso, verify_iso
+from lib.iso import find_file_in_iso, update_dir_entry, verify_iso
 from lib.cddata import build_mapping, patch_cddata
-from lib.video import (
-    extract_dsi_audio, extract_dsi_video, patch_dsi_audio,
-    encode_subtitled_video, mux_dsi_proportional, dump_mkv,
-)
+from lib.video import build_subtitled_dsi, dump_mkv
 from lib.ffmpeg import find_or_build_ffmpeg
 
 
@@ -97,10 +94,10 @@ def generate_xdelta(usa_iso_path, out_iso_path):
 # =============================================================================
 
 def do_audio(usa_iso_path, jp_iso_path, out_iso_path):
-    """Audio-only undub: JP audio in all cutscenes + CDDATA, no subtitles.
+    """Audio-only undub: full JP DSIs (no size constraint) + CDDATA patching.
 
-    This produces a perfectly playable ISO with Japanese voices and
-    original English video. No ffmpeg required.
+    Writes JP cutscenes sequentially into the ISO, relocating files and
+    updating ISO9660 directory entries. No bitrate-constrained encoding.
     """
     print("Reading ISOs...")
     with open(usa_iso_path, 'rb') as f:
@@ -110,7 +107,7 @@ def do_audio(usa_iso_path, jp_iso_path, out_iso_path):
 
     shutil.copy2(usa_iso_path, out_iso_path)
 
-    # Patch CDDATA.DIG
+    # --- Step 1: Patch CDDATA.DIG (in-place, same size) ---
     mapping = build_mapping(usa_iso, jp_iso)
     print(f"  Mapping: {len(mapping)} entries")
 
@@ -123,40 +120,52 @@ def do_audio(usa_iso_path, jp_iso_path, out_iso_path):
     patched_dig, replaced, skipped_same, skipped_nofit = patch_cddata(usa_dig, jp_dig, mapping)
     print(f"  Replaced: {replaced}, Skipped (identical): {skipped_same}, Skipped (too large): {skipped_nofit}")
 
-    with open(out_iso_path, 'r+b') as iso_f:
-        iso_f.seek(usa_cddata_info[0] * SECTOR_SIZE)
-        iso_f.write(patched_dig[:usa_cddata_info[1]])
+    with open(out_iso_path, 'r+b') as f:
+        f.seek(usa_cddata_info[0] * SECTOR_SIZE)
+        f.write(patched_dig[:usa_cddata_info[1]])
 
-        # Patch DSI cutscene audio
-        print("Patching cutscene audio...")
+    # --- Step 2: Write JP DSIs sequentially ---
+    print("Writing JP cutscenes...")
+
+    # DSIs start right after CDDATA.DIG
+    cddata_end = usa_cddata_info[0] + (usa_cddata_info[1] + SECTOR_SIZE - 1) // SECTOR_SIZE
+    write_sector = cddata_end
+
+    with open(out_iso_path, 'r+b') as f:
         for name in DSI_NAMES:
             usa_info = find_file_in_iso(usa_iso, f'{name}.DSI;1'.encode())
             jp_info = find_file_in_iso(jp_iso, f'{name}.DSI;1'.encode())
             if not usa_info or not jp_info:
                 continue
 
-            usa_sec, usa_sz, usa_dir = usa_info
             jp_sec, jp_sz, _ = jp_info
+            jp_dsi = jp_iso[jp_sec * SECTOR_SIZE:jp_sec * SECTOR_SIZE + jp_sz]
 
-            if name == 'M000':
-                # Opening: replace entire DSI with JP version (different video+audio)
-                jp_dsi = jp_iso[jp_sec * SECTOR_SIZE:jp_sec * SECTOR_SIZE + jp_sz]
-                iso_f.seek(usa_sec * SECTOR_SIZE)
-                iso_f.write(jp_dsi)
-                if jp_sz > usa_sz:
-                    # Patch ISO directory entry for larger file
-                    iso_f.seek(usa_dir + 10)
-                    iso_f.write(struct.pack('<I', jp_sz))
-                    iso_f.write(struct.pack('>I', jp_sz))
-                print(f"  {name}: full JP DSI")
-            else:
-                usa_dsi = usa_iso[usa_sec * SECTOR_SIZE:usa_sec * SECTOR_SIZE + usa_sz]
-                jp_dsi = jp_iso[jp_sec * SECTOR_SIZE:jp_sec * SECTOR_SIZE + jp_sz]
-                jp_audio = extract_dsi_audio(jp_dsi)
-                patched = patch_dsi_audio(usa_dsi, jp_audio)
-                iso_f.seek(usa_sec * SECTOR_SIZE)
-                iso_f.write(patched)
-                print(f"  {name}: JP audio")
+            f.seek(write_sector * SECTOR_SIZE)
+            f.write(jp_dsi)
+            pad = (SECTOR_SIZE - (jp_sz % SECTOR_SIZE)) % SECTOR_SIZE
+            if pad:
+                f.write(b'\x00' * pad)
+
+            update_dir_entry(f, usa_info[2], write_sector, jp_sz)
+
+            file_sectors = (jp_sz + SECTOR_SIZE - 1) // SECTOR_SIZE
+            print(f"  {name}: {jp_sz / 1024 / 1024:.1f} MB")
+            write_sector += file_sectors
+
+        # DATA0 (runtime scratchpad) — relocate after last DSI
+        data0_info = find_file_in_iso(usa_iso, b'DATA0')
+        if data0_info:
+            data0_sec, data0_sz, data0_dir = data0_info
+            data0_content = usa_iso[data0_sec * SECTOR_SIZE:data0_sec * SECTOR_SIZE + data0_sz]
+            f.seek(write_sector * SECTOR_SIZE)
+            f.write(data0_content)
+            update_dir_entry(f, data0_dir, write_sector, data0_sz)
+            write_sector += (data0_sz + SECTOR_SIZE - 1) // SECTOR_SIZE
+
+        # Truncate ISO to actual size
+        f.seek(write_sector * SECTOR_SIZE)
+        f.truncate()
 
     return usa_iso, jp_iso
 
@@ -169,98 +178,103 @@ def do_full(usa_iso_path, jp_iso_path, out_iso_path, dump_mkv_dir=None):
     """Full pipeline: JP audio + burned English subtitles on all cutscenes.
 
     For each cutscene:
-    1. Extract video (USA for most, JP for M000 opening)
-    2. Encode with subtitles burned in (MPEG-2 CBR, PS2-compatible)
-    3. Mux with proportional audio into DSI blocks (perfect A/V sync)
-    4. Optionally export as MKV for preview
+    1. Take JP DSI (video + audio)
+    2. Burn English subtitles onto JP video
+    3. Remux with dsi-muxer (auto block count, no size constraint)
+    4. Write sequentially into ISO, relocating files as needed
     """
-    # First do audio-only patching (CDDATA + DSI audio)
-    usa_iso, jp_iso = do_audio(usa_iso_path, jp_iso_path, out_iso_path)
+    print("Reading ISOs...")
+    with open(usa_iso_path, 'rb') as f:
+        usa_iso = f.read()
+    with open(jp_iso_path, 'rb') as f:
+        jp_iso = f.read()
 
-    # Find or build ffmpeg with libass
-    print("\nSetting up subtitle burning...")
+    shutil.copy2(usa_iso_path, out_iso_path)
+
+    # --- Step 1: Patch CDDATA.DIG ---
+    mapping = build_mapping(usa_iso, jp_iso)
+    print(f"  Mapping: {len(mapping)} entries")
+
+    print("Patching CDDATA.DIG...")
+    usa_cddata_info = find_file_in_iso(usa_iso, b'CDDATA.DIG;1')
+    jp_cddata_info = find_file_in_iso(jp_iso, b'CDDATA.DIG;1')
+    usa_dig = usa_iso[usa_cddata_info[0] * SECTOR_SIZE:usa_cddata_info[0] * SECTOR_SIZE + usa_cddata_info[1]]
+    jp_dig = jp_iso[jp_cddata_info[0] * SECTOR_SIZE:jp_cddata_info[0] * SECTOR_SIZE + jp_cddata_info[1]]
+
+    patched_dig, replaced, skipped_same, skipped_nofit = patch_cddata(usa_dig, jp_dig, mapping)
+    print(f"  Replaced: {replaced}, Skipped (identical): {skipped_same}, Skipped (too large): {skipped_nofit}")
+
+    with open(out_iso_path, 'r+b') as f:
+        f.seek(usa_cddata_info[0] * SECTOR_SIZE)
+        f.write(patched_dig[:usa_cddata_info[1]])
+
+    # --- Step 2: Build subtitled DSIs and write sequentially ---
     ffmpeg_bin = find_or_build_ffmpeg()
     if not ffmpeg_bin:
-        print("WARNING: Could not get ffmpeg with libass — skipping subtitles")
-        return
+        print("WARNING: Could not get ffmpeg with libass — falling back to audio-only")
 
     if dump_mkv_dir:
         os.makedirs(dump_mkv_dir, exist_ok=True)
 
-    # Burn subtitles + mux with proportional audio
-    print("Burning subtitles into cutscene video...")
+    print("Writing cutscenes...")
+    cddata_end = usa_cddata_info[0] + (usa_cddata_info[1] + SECTOR_SIZE - 1) // SECTOR_SIZE
+    write_sector = cddata_end
 
-    with open(out_iso_path, 'r+b') as iso_f:
+    with open(out_iso_path, 'r+b') as f:
         for name in DSI_NAMES:
-            ass_path = os.path.join(SUBS_DIR, f'{name}.ass')
-            if not os.path.exists(ass_path):
+            usa_info = find_file_in_iso(usa_iso, f'{name}.DSI;1'.encode())
+            jp_info = find_file_in_iso(jp_iso, f'{name}.DSI;1'.encode())
+            if not usa_info or not jp_info:
                 continue
-            with open(ass_path) as f:
-                if 'Dialogue:' not in f.read():
-                    continue
 
-            # M000 uses JP video (different opening), others use USA video
-            if name == 'M000':
-                jp_info = find_file_in_iso(jp_iso, f'{name}.DSI;1'.encode())
-                usa_info = find_file_in_iso(usa_iso, f'{name}.DSI;1'.encode())
-                if not jp_info or not usa_info:
-                    continue
-                jp_sec, jp_sz, _ = jp_info
-                usa_sec, usa_sz, usa_dir = usa_info
-                jp_dsi = jp_iso[jp_sec * SECTOR_SIZE:jp_sec * SECTOR_SIZE + jp_sz]
-                src_video = extract_dsi_video(jp_dsi)
-                jp_audio = extract_dsi_audio(jp_dsi)
-                nblocks = jp_sz // DSI_BLOCK_SIZE
+            jp_sec, jp_sz, _ = jp_info
+            jp_dsi_bytes = jp_iso[jp_sec * SECTOR_SIZE:jp_sec * SECTOR_SIZE + jp_sz]
+
+            # Try to build subtitled DSI
+            ass_path = os.path.join(SUBS_DIR, f'{name}.ass')
+            has_subs = (ffmpeg_bin and os.path.exists(ass_path) and
+                        'Dialogue:' in open(ass_path).read())
+
+            if has_subs:
+                sub_dsi = build_subtitled_dsi(ffmpeg_bin, jp_dsi_bytes, ass_path)
+
+                if dump_mkv_dir and sub_dsi is not None:
+                    from dsi_muxer import DSI
+                    src = DSI.from_bytes(jp_dsi_bytes)
+                    mkv_path = os.path.join(dump_mkv_dir, f'{name}.mkv')
+                    dump_mkv(ffmpeg_bin, sub_dsi, src.extract_audio(), mkv_path)
+                    if os.path.exists(mkv_path):
+                        print(f"    -> {mkv_path}")
             else:
-                usa_info = find_file_in_iso(usa_iso, f'{name}.DSI;1'.encode())
-                if not usa_info:
-                    continue
-                usa_sec, usa_sz, _ = usa_info
-                nblocks = usa_sz // DSI_BLOCK_SIZE
-                iso_f.seek(usa_sec * SECTOR_SIZE)
-                dsi_data = iso_f.read(usa_sz)
-                src_video = extract_dsi_video(dsi_data)
-                jp_audio = extract_dsi_audio(dsi_data)
+                sub_dsi = None
 
-            with tempfile.TemporaryDirectory() as tmp:
-                m2v_in = os.path.join(tmp, f'{name}.m2v')
-                m2v_out = os.path.join(tmp, f'{name}_sub.m2v')
+            dsi_data = sub_dsi if sub_dsi is not None else jp_dsi_bytes
+            label = "subtitled" if sub_dsi is not None else "JP audio"
 
-                with open(m2v_in, 'wb') as f:
-                    f.write(src_video)
+            f.seek(write_sector * SECTOR_SIZE)
+            f.write(dsi_data)
+            pad = (SECTOR_SIZE - (len(dsi_data) % SECTOR_SIZE)) % SECTOR_SIZE
+            if pad:
+                f.write(b'\x00' * pad)
 
-                if encode_subtitled_video(ffmpeg_bin, m2v_in, ass_path, m2v_out,
-                                          nblocks, len(jp_audio)):
-                    with open(m2v_out, 'rb') as f:
-                        new_video = f.read()
-                    patched = mux_dsi_proportional(new_video, jp_audio, nblocks)
+            update_dir_entry(f, usa_info[2], write_sector, len(dsi_data))
 
-                    # Verify end-of-sequence
-                    if b'\x00\x00\x01\xb7' not in patched:
-                        print(f"  {name}: WARNING — missing end-of-sequence!")
+            file_sectors = (len(dsi_data) + SECTOR_SIZE - 1) // SECTOR_SIZE
+            print(f"  {name}: {len(dsi_data) / 1024 / 1024:.1f} MB ({label})")
+            write_sector += file_sectors
 
-                    # Write to ISO
-                    if name == 'M000':
-                        iso_f.seek(usa_sec * SECTOR_SIZE)
-                        iso_f.write(patched)
-                        if len(patched) > usa_sz:
-                            iso_f.seek(usa_dir + 10)
-                            iso_f.write(struct.pack('<I', len(patched)))
-                            iso_f.write(struct.pack('>I', len(patched)))
-                    else:
-                        iso_f.seek(usa_sec * SECTOR_SIZE)
-                        iso_f.write(patched)
+        # DATA0
+        data0_info = find_file_in_iso(usa_iso, b'DATA0')
+        if data0_info:
+            data0_sec, data0_sz, data0_dir = data0_info
+            data0_content = usa_iso[data0_sec * SECTOR_SIZE:data0_sec * SECTOR_SIZE + data0_sz]
+            f.seek(write_sector * SECTOR_SIZE)
+            f.write(data0_content)
+            update_dir_entry(f, data0_dir, write_sector, data0_sz)
+            write_sector += (data0_sz + SECTOR_SIZE - 1) // SECTOR_SIZE
 
-                    print(f"  {name}: subtitled")
-
-                    # Export MKV with squeezed JP audio
-                    if dump_mkv_dir:
-                        mkv_path = os.path.join(dump_mkv_dir, f'{name}.mkv')
-                        dump_mkv(ffmpeg_bin, m2v_out, jp_audio, tmp, mkv_path)
-                        if os.path.exists(mkv_path):
-                            print(f"    -> {mkv_path}")
-                else:
-                    print(f"  {name}: subtitle burn failed, keeping audio-only")
+        f.seek(write_sector * SECTOR_SIZE)
+        f.truncate()
 
 
 # =============================================================================

--- a/patch.py
+++ b/patch.py
@@ -28,7 +28,7 @@ import subprocess
 import tempfile
 
 from lib.constants import (
-    DSI_BLOCK_SIZE, SECTOR_SIZE, EXPECTED_HASHES,
+    DSI_BLOCK_SIZE, SECTOR, EXPECTED_HASHES,
     DSI_NAMES, SUBS_DIR,
 )
 from lib.iso import find_file_in_iso, update_dir_entry, verify_iso
@@ -114,21 +114,21 @@ def do_audio(usa_iso_path, jp_iso_path, out_iso_path):
     print("Patching CDDATA.DIG...")
     usa_cddata_info = find_file_in_iso(usa_iso, b'CDDATA.DIG;1')
     jp_cddata_info = find_file_in_iso(jp_iso, b'CDDATA.DIG;1')
-    usa_dig = usa_iso[usa_cddata_info[0] * SECTOR_SIZE:usa_cddata_info[0] * SECTOR_SIZE + usa_cddata_info[1]]
-    jp_dig = jp_iso[jp_cddata_info[0] * SECTOR_SIZE:jp_cddata_info[0] * SECTOR_SIZE + jp_cddata_info[1]]
+    usa_dig = usa_iso[usa_cddata_info[0] * SECTOR:usa_cddata_info[0] * SECTOR + usa_cddata_info[1]]
+    jp_dig = jp_iso[jp_cddata_info[0] * SECTOR:jp_cddata_info[0] * SECTOR + jp_cddata_info[1]]
 
     patched_dig, replaced, skipped_same, skipped_nofit = patch_cddata(usa_dig, jp_dig, mapping)
     print(f"  Replaced: {replaced}, Skipped (identical): {skipped_same}, Skipped (too large): {skipped_nofit}")
 
     with open(out_iso_path, 'r+b') as f:
-        f.seek(usa_cddata_info[0] * SECTOR_SIZE)
+        f.seek(usa_cddata_info[0] * SECTOR)
         f.write(patched_dig[:usa_cddata_info[1]])
 
     # --- Step 2: Write JP DSIs sequentially ---
     print("Writing JP cutscenes...")
 
     # DSIs start right after CDDATA.DIG
-    cddata_end = usa_cddata_info[0] + (usa_cddata_info[1] + SECTOR_SIZE - 1) // SECTOR_SIZE
+    cddata_end = usa_cddata_info[0] + (usa_cddata_info[1] + SECTOR - 1) // SECTOR
     write_sector = cddata_end
 
     with open(out_iso_path, 'r+b') as f:
@@ -139,17 +139,17 @@ def do_audio(usa_iso_path, jp_iso_path, out_iso_path):
                 continue
 
             jp_sec, jp_sz, _ = jp_info
-            jp_dsi = jp_iso[jp_sec * SECTOR_SIZE:jp_sec * SECTOR_SIZE + jp_sz]
+            jp_dsi = jp_iso[jp_sec * SECTOR:jp_sec * SECTOR + jp_sz]
 
-            f.seek(write_sector * SECTOR_SIZE)
+            f.seek(write_sector * SECTOR)
             f.write(jp_dsi)
-            pad = (SECTOR_SIZE - (jp_sz % SECTOR_SIZE)) % SECTOR_SIZE
+            pad = (SECTOR - (jp_sz % SECTOR)) % SECTOR
             if pad:
                 f.write(b'\x00' * pad)
 
             update_dir_entry(f, usa_info[2], write_sector, jp_sz)
 
-            file_sectors = (jp_sz + SECTOR_SIZE - 1) // SECTOR_SIZE
+            file_sectors = (jp_sz + SECTOR - 1) // SECTOR
             print(f"  {name}: {jp_sz / 1024 / 1024:.1f} MB")
             write_sector += file_sectors
 
@@ -157,14 +157,14 @@ def do_audio(usa_iso_path, jp_iso_path, out_iso_path):
         data0_info = find_file_in_iso(usa_iso, b'DATA0')
         if data0_info:
             data0_sec, data0_sz, data0_dir = data0_info
-            data0_content = usa_iso[data0_sec * SECTOR_SIZE:data0_sec * SECTOR_SIZE + data0_sz]
-            f.seek(write_sector * SECTOR_SIZE)
+            data0_content = usa_iso[data0_sec * SECTOR:data0_sec * SECTOR + data0_sz]
+            f.seek(write_sector * SECTOR)
             f.write(data0_content)
             update_dir_entry(f, data0_dir, write_sector, data0_sz)
-            write_sector += (data0_sz + SECTOR_SIZE - 1) // SECTOR_SIZE
+            write_sector += (data0_sz + SECTOR - 1) // SECTOR
 
         # Truncate ISO to actual size
-        f.seek(write_sector * SECTOR_SIZE)
+        f.seek(write_sector * SECTOR)
         f.truncate()
 
     return usa_iso, jp_iso
@@ -198,14 +198,14 @@ def do_full(usa_iso_path, jp_iso_path, out_iso_path, dump_mkv_dir=None):
     print("Patching CDDATA.DIG...")
     usa_cddata_info = find_file_in_iso(usa_iso, b'CDDATA.DIG;1')
     jp_cddata_info = find_file_in_iso(jp_iso, b'CDDATA.DIG;1')
-    usa_dig = usa_iso[usa_cddata_info[0] * SECTOR_SIZE:usa_cddata_info[0] * SECTOR_SIZE + usa_cddata_info[1]]
-    jp_dig = jp_iso[jp_cddata_info[0] * SECTOR_SIZE:jp_cddata_info[0] * SECTOR_SIZE + jp_cddata_info[1]]
+    usa_dig = usa_iso[usa_cddata_info[0] * SECTOR:usa_cddata_info[0] * SECTOR + usa_cddata_info[1]]
+    jp_dig = jp_iso[jp_cddata_info[0] * SECTOR:jp_cddata_info[0] * SECTOR + jp_cddata_info[1]]
 
     patched_dig, replaced, skipped_same, skipped_nofit = patch_cddata(usa_dig, jp_dig, mapping)
     print(f"  Replaced: {replaced}, Skipped (identical): {skipped_same}, Skipped (too large): {skipped_nofit}")
 
     with open(out_iso_path, 'r+b') as f:
-        f.seek(usa_cddata_info[0] * SECTOR_SIZE)
+        f.seek(usa_cddata_info[0] * SECTOR)
         f.write(patched_dig[:usa_cddata_info[1]])
 
     # --- Step 2: Build subtitled DSIs and write sequentially ---
@@ -217,7 +217,7 @@ def do_full(usa_iso_path, jp_iso_path, out_iso_path, dump_mkv_dir=None):
         os.makedirs(dump_mkv_dir, exist_ok=True)
 
     print("Writing cutscenes...")
-    cddata_end = usa_cddata_info[0] + (usa_cddata_info[1] + SECTOR_SIZE - 1) // SECTOR_SIZE
+    cddata_end = usa_cddata_info[0] + (usa_cddata_info[1] + SECTOR - 1) // SECTOR
     write_sector = cddata_end
 
     with open(out_iso_path, 'r+b') as f:
@@ -228,7 +228,7 @@ def do_full(usa_iso_path, jp_iso_path, out_iso_path, dump_mkv_dir=None):
                 continue
 
             jp_sec, jp_sz, _ = jp_info
-            jp_dsi_bytes = jp_iso[jp_sec * SECTOR_SIZE:jp_sec * SECTOR_SIZE + jp_sz]
+            jp_dsi_bytes = jp_iso[jp_sec * SECTOR:jp_sec * SECTOR + jp_sz]
 
             # Try to build subtitled DSI
             ass_path = os.path.join(SUBS_DIR, f'{name}.ass')
@@ -251,15 +251,15 @@ def do_full(usa_iso_path, jp_iso_path, out_iso_path, dump_mkv_dir=None):
             dsi_data = sub_dsi if sub_dsi is not None else jp_dsi_bytes
             label = "subtitled" if sub_dsi is not None else "JP audio"
 
-            f.seek(write_sector * SECTOR_SIZE)
+            f.seek(write_sector * SECTOR)
             f.write(dsi_data)
-            pad = (SECTOR_SIZE - (len(dsi_data) % SECTOR_SIZE)) % SECTOR_SIZE
+            pad = (SECTOR - (len(dsi_data) % SECTOR)) % SECTOR
             if pad:
                 f.write(b'\x00' * pad)
 
             update_dir_entry(f, usa_info[2], write_sector, len(dsi_data))
 
-            file_sectors = (len(dsi_data) + SECTOR_SIZE - 1) // SECTOR_SIZE
+            file_sectors = (len(dsi_data) + SECTOR - 1) // SECTOR
             print(f"  {name}: {len(dsi_data) / 1024 / 1024:.1f} MB ({label})")
             write_sector += file_sectors
 
@@ -267,13 +267,13 @@ def do_full(usa_iso_path, jp_iso_path, out_iso_path, dump_mkv_dir=None):
         data0_info = find_file_in_iso(usa_iso, b'DATA0')
         if data0_info:
             data0_sec, data0_sz, data0_dir = data0_info
-            data0_content = usa_iso[data0_sec * SECTOR_SIZE:data0_sec * SECTOR_SIZE + data0_sz]
-            f.seek(write_sector * SECTOR_SIZE)
+            data0_content = usa_iso[data0_sec * SECTOR:data0_sec * SECTOR + data0_sz]
+            f.seek(write_sector * SECTOR)
             f.write(data0_content)
             update_dir_entry(f, data0_dir, write_sector, data0_sz)
-            write_sector += (data0_sz + SECTOR_SIZE - 1) // SECTOR_SIZE
+            write_sector += (data0_sz + SECTOR - 1) // SECTOR
 
-        f.seek(write_sector * SECTOR_SIZE)
+        f.seek(write_sector * SECTOR)
         f.truncate()
 
 


### PR DESCRIPTION
## Summary

- **No more size-constrained encoding**: JP DSIs are written sequentially into the ISO with directory entries updated. Block count is auto-calculated by dsi-muxer 1.2.0.
- **JP video source**: Subtitles are now burned onto JP video (was USA video). Better quality since we re-encode from the original source.
- **Fixed 7000k bitrate**: No more per-cutscene bitrate calculation to fit DSI slots. All cutscenes encode at the same quality.
- **ISO restructuring**: Files are compacted (DSIs → DATA0), ISO truncated to actual size. Result is ~1.8GB (smaller than the 1.84GB original).
- **Simplified code**: Removed M000 special-casing, `patch_dsi_audio`/`extract_dsi_audio` usage, and bitrate calculation logic. New `build_subtitled_dsi()` handles the full pipeline.

Depends on dsi-muxer 1.2.0 (soyjxck/dsi-muxer#1).

## Test plan

- [x] Audio-only build boots and plays cutscenes
- [x] Full build with subtitles — all 16 cutscenes burn successfully
- [x] Menu sounds and combat voices working
- [x] M002 A/V sync verified
- [ ] Full playthrough test

🤖 Generated with [Claude Code](https://claude.com/claude-code)