### PR TITLE
Lossless wholesale audio replacement via DigArchive grow

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,18 +83,15 @@ We developed a **proportional audio DSI muxer** (the first of its kind — see [
 
 ### Audio (CDDATA.DIG)
 
-Game audio lives in Racjin's compressed CDDATA.DIG archive. We use **per-sample SCEI sound bank replacement**: individual voice samples within banks are replaced with JP equivalents while keeping shared SFX (menu sounds, combat effects) untouched. Oversized JP samples are resampled to fit USA slots using psxavenc (vgmstream decode → ffmpeg resample → psxavenc re-encode).
+Game audio lives in Racjin's compressed CDDATA.DIG archive — a flat TOC of entries holding voice clips, SFX, music, and SCEI sound banks. We replace each USA entry wholesale with its JP counterpart. When a JP entry is larger than the original USA slot, the archive grows: we append the new entry at end-of-DIG, repoint the TOC sector, and update CDDATA.DIG's ISO9660 directory entry so the file's new sector and size are visible to the game. Result: every JP audio entry replaces its USA counterpart at full original quality, with no resampling.
+
+Earlier versions did per-sample surgery inside SCEI sound banks to preserve USA SFX. That's unnecessary now that the archive can grow — the SFX samples shared between regions are byte-identical, so wholesale-JP banks already contain them in the right positions. See [issue #4](https://github.com/soyjxck/fma-broken-angel-undub/issues/4) for the discussion that led to this simplification.
 
 Compression handled by the [racjin-python](https://github.com/soyjxck/racjin-python) library.
 
-## Known Limitations
-
-- Some in-game dialogue entries have reduced audio quality (JP samples resampled to fit smaller USA slots)
-- Cutscene video re-encoded at ~90-95% bitrate to fit proportional audio distribution
-
 ## Fonts
 
-Subtitles use **Helvetica** and **Geometric Slabserif 703** (opening title cards). These fonts are not bundled — subtitle rendering requires them to be installed on the build machine. The xdelta release has subtitles pre-burned into the video, so fonts are only relevant when building from source.
+Subtitle dialogue uses **Serifa Std** and title cards use **Geometric Slabserif 703 Extra Bold Condensed**. These fonts are not bundled — subtitle rendering requires them to be installed on the build machine. The xdelta release has subtitles pre-burned into the video, so fonts are only relevant when building from source.
 
 ## Credits
 

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -632,22 +632,21 @@ Small files with unidentified formats.
 
 All audio in both versions has been fully extracted and accounted for. The 101-entry lookup table in both executables provides exact 1:1 mapping (see [USA <-> JP Entry Mapping](#usa--jp-entry-mapping) section).
 
-### Undub ISO Status (FMA_Undub.iso) — v5.1 COMPLETE
+### Undub ISO Status (FMA_Undub.iso) — v5.12
 
 | Component | Status |
 |-----------|--------|
 | DSI cutscene audio (18/18) | Replaced with JP audio ✓ |
 | DSI cutscene video (18/18) | Burned English subtitles ✓ |
-| CDDATA.DIG lookup table (101 entries) | All replaced ✓ |
-| CDDATA.DIG SCEI hash-matched banks (85 entries) | Per-sample SCEI replacement ✓ |
-| CDDATA.DIG voice-only banks (12 entries) | Per-sample replacement ✓ (includes Edward's combat grunts) |
+| CDDATA.DIG lookup table (101 entries) | All replaced wholesale ✓ |
+| CDDATA.DIG SCEI hash-matched banks (85 entries) | Replaced wholesale; shared SFX preserved by byte-equality ✓ |
+| CDDATA.DIG voice-only banks (12 entries) | Replaced wholesale (includes Edward's combat grunts) ✓ |
 | **Total CDDATA.DIG entries replaced** | **198** |
-| Per-sample SCEI replacement | Voice samples replaced individually, SFX preserved ✓ |
-| Force-fit resampled entries | Oversized JP samples resampled via psxavenc to fit ✓ |
-| Truncated entries | **0** (no truncation in v5.1) |
+| Resampled / quality-reduced entries | **0** — JP audio always at original sample rate |
+| Truncated entries | **0** |
 | Proportional audio muxer | DSI A/V sync solved via frame-proportional audio distribution ✓ |
 
-The undub ISO was built by patching the original USA ISO in-place (preserving PS2 boot sector) using pycdlib for file location lookup. Per-sample SCEI replacement preserves bank structure: voice samples replaced with JP equivalents, SFX samples (hash-matched identical) left untouched, shorter samples zero-padded. Oversized JP samples resampled to fit via psxavenc force-fit pipeline (lowest resampled rate ~7 kHz). DSI cutscenes use proportional audio muxer for correct A/V sync, with burned English subtitles on video. Edward's Japanese combat grunts confirmed working in PCSX2.
+The undub ISO is built by patching the original USA ISO in-place (preserving PS2 boot sector). All audio replacements are wholesale — each USA CDDATA.DIG entry swapped for its JP equivalent at the entry's TOC level. When a JP entry is larger than the original USA slot the archive grows: the entry is appended at end-of-DIG, the TOC sector is repointed, and CDDATA.DIG's ISO9660 directory entry is updated so the file's new sector and size are visible to the game. SCEI sound banks are handled the same way as any other entry: shared SFX between regions are byte-identical (the basis for `SCEI_BANK_MAP`), so wholesale replacement preserves them automatically. DSI cutscenes use the proportional audio muxer for A/V sync, with burned English subtitles on video. Edward's Japanese combat grunts confirmed working in PCSX2.
 
 ### Output Directories
 
@@ -810,25 +809,52 @@ The larger container files (0433-0577) contain sound banks — sub-entries with 
 - End-of-sequence marker (0x000001B7) injected in post-processing to signal the PS2 MPEG decoder
 - Published as `dsi-muxer` library
 
-### Step 27: SCEI Per-Sample Replacement (v5.0)
+### Step 27: SCEI Per-Sample Replacement (v5.0, superseded by Step 30)
 - Parse SCEIVagi tags as LE uint32 pairs to extract per-sample BD offsets and sample rates
 - Hash compare each sample between USA and JP: identical hash = SFX (skip), different hash = voice (replace if fits)
 - Preserves full bank structure: header chunks, offset tables, and BD layout unchanged
 - Shorter JP samples zero-padded to match USA sample slot size
 - Menu sounds and SFX preserved automatically by hash-match skip logic
+- **Why this existed**: at the time, CDDATA.DIG was patched in place at fixed
+  size (`f.write(patched_dig[:usa_cddata_info[1]])`), so wholesale-replacing an
+  oversized JP bank meant truncation. Per-sample surgery kept each bank at its
+  original USA size while still swapping the voice samples.
 
-### Step 28: Force-Fit Resampling + Entry 105/107/108 Fix (v5.1)
+### Step 28: Force-Fit Resampling + Entry 105/107/108 Fix (v5.1, superseded by Step 30)
 - Corrected 105/107/108 mapping from JP 491 to JP 263
 - USA 105 = 107 = 108 (identical content). Traced via shared samples: banks 106 -> JP 263, 109 -> JP 264
 - JP index offset detection: JP has 1 SFX + 3 voice samples, USA has 3 voice samples (JP index shifted by 1)
 - psxavenc pipeline for oversized JP samples: decode JP ADPCM -> resample to lower rate -> re-encode as PS2 SPU ADPCM at target size
 - JP entries 105/107/108 themselves use an unknown non-SCEI format (not replaced)
+- The mapping fix is permanent; the resample pipeline was retired in Step 30.
 
 ### Step 29: ffmpeg libass Build Fix (v5.1)
 - Two bugs in the auto-build ffmpeg pipeline:
   1. 'ass' substring false positive in filter detection (matched unrelated filters containing "ass")
   2. configure argument indexing error putting `-I` flag on wrong argument
 - Both fixed to enable reliable cross-platform ffmpeg+libass builds for subtitle burning
+
+### Step 30: Lossless Wholesale via DigArchive Grow (v5.12)
+- [Issue #4](https://github.com/soyjxck/fma-broken-angel-undub/issues/4) raised by
+  `renkin-jit` pointed out that the per-sample / force-fit machinery only existed
+  because CDDATA.DIG was being written back at fixed size. ISO9660 has no such
+  constraint — like any other file, the DIG can be relocated and resized via its
+  directory entry.
+- Introduced `DigArchive` in `lib/cddata.py`: a sector-addressed wrapper that
+  reads/writes entries through their TOC. `write_entry()` writes in place when
+  the new entry fits the original slot; otherwise it appends at end-of-DIG and
+  re-points the TOC sector — the archive grows freely.
+- Added `read_file_from_iso` / `write_file_to_iso` in `lib/iso.py`, hiding all
+  ISO sector arithmetic and `update_dir_entry` calls behind a file-level API.
+  `patch.py` now writes the (possibly grown) CDDATA.DIG at end of ISO with the
+  same plumbing already used for DSIs and DATA0.
+- Result: every JP audio entry replaces its USA counterpart at full quality.
+  No psxavenc resample pipeline, no zero-pad-to-slot, no per-sample SCEI surgery.
+- SCEI banks fall out for free: the shared SFX samples that `SCEI_BANK_MAP` was
+  built from are byte-identical between USA and JP banks, so wholesale-JP
+  preserves them automatically. The complex per-sample logic from Step 27 was
+  retired (`_parse_scei_samples`, `_patch_scei_bank`, `_fit_sample_psxavenc`).
+- Code reduction: `lib/cddata.py` shrank from 413 to 182 lines.
 
 ---
 
@@ -1079,10 +1105,9 @@ The combat containers turned out to be a red herring for audio replacement. The 
 
 ## What Remains
 
-**PROJECT COMPLETE.** Undub patch v5.1 published, verified, and fully reproducible.
+**PROJECT COMPLETE.** Undub patch v5.12 published, verified, and fully reproducible. As of v5.12 every JP audio replacement is lossless — see Step 30.
 
-- Minor: ~47 CDDATA entries where JP data was too large for the ISO slot were force-fit resampled via psxavenc. Lowest resampled rate is ~7 kHz (reduced quality but audible).
-- Minor: 1 USA sample in bank 154 has no JP equivalent.
+- Minor: 1 USA sample in bank 154 has no JP equivalent (kept as-is).
 
 ---
 
@@ -1097,7 +1122,6 @@ The combat containers turned out to be a red herring for audio replacement. The 
 | **TXTH format** | vgmstream's text-based header descriptor for headerless audio files |
 | **Racjin-de-compression** | Reference C++ implementation. Clone: `git clone https://github.com/Raw-man/Racjin-de-compression.git` |
 | **OpenAI Whisper** (small model) | Speech-to-text transcription for cutscene subtitles. Install: `pip install openai-whisper` |
-| **psxavenc** | PS2 SPU-ADPCM encoder for force-fit resampling of oversized JP samples. Source: `WonderfulToolchain/psxavenc` |
 | **dsi-muxer** | Proportional audio DSI muxer for A/V sync in remuxed cutscenes. Published: `soyjxck/dsi-muxer` |
 
 ### TXTH Template (works for ALL audio in this game)
@@ -1118,7 +1142,7 @@ Save as `yourfile.adpcm.txth` alongside the raw `.adpcm` file and vgmstream will
 
 | Artifact | Location | Description |
 |----------|----------|-------------|
-| **fma-broken-angel-undub v5.1** | GitHub: `soyjxck/fma-broken-angel-undub` | xdelta patch, patch.py (3-mode unified patcher: full/audio/xdelta), ASS subtitles in `subs/`, technical docs. Cross-platform (macOS/Linux/Windows via MSYS2). Per-sample SCEI replacement, force-fit resampling, proportional DSI muxer, no truncation. |
+| **fma-broken-angel-undub v5.12** | GitHub: `soyjxck/fma-broken-angel-undub` | xdelta patch, patch.py (3-mode unified patcher: full/audio/xdelta), ASS subtitles in `subs/`, technical docs. Cross-platform (macOS/Linux/Windows via MSYS2). Wholesale lossless audio replacement via DigArchive grow, proportional DSI muxer. |
 | **racjin-python** | GitHub: `soyjxck/racjin-python` | Racjin compression/decompression Python library |
 | **dsi-muxer** | GitHub: `soyjxck/dsi-muxer` | Proportional audio DSI muxer library for PS2 cutscene A/V sync |
 | **patch.py** | GitHub repo | Unified patcher: `full` (subs+audio, auto-builds ffmpeg with libass), `audio` (audio-only, just Python), `xdelta` (apply pre-built patch) |

--- a/lib/cddata.py
+++ b/lib/cddata.py
@@ -1,261 +1,95 @@
 """
 CDDATA.DIG patching — replaces audio entries with Japanese versions.
 
-The CDDATA.DIG file is Racjin's game archive containing all non-cutscene
-audio: dialogue, combat voices, SFX, music, and menu sounds.
+CDDATA.DIG is Racjin's archive for all non-cutscene audio (dialogue,
+combat voices, SFX, music, menu sounds). Layout is a flat table of
+16-byte TOC records at offset 0, followed by sector-aligned entry data
+— see DigArchive below.
 
-Patching strategy:
-1. Skip identical entries (shared SFX/music between regions)
-2. Direct replacement when JP data fits in the USA slot
-3. Racjin recompression when JP data is too large but compressible
-4. SCEI per-sample replacement for sound banks (voice only, SFX preserved)
-5. Keep USA version if nothing else works (never truncate)
+Per entry, the patcher:
+1. Skips byte-identical entries (shared SFX/music between regions)
+2. Replaces wholesale with the JP entry — DigArchive grows when JP is
+   larger than the original slot, by appending at end-of-DIG and
+   repointing the TOC sector. All paths are lossless.
+
+Earlier versions did per-sample SCEI bank surgery (preserving USA SFX
+inside mixed banks while replacing voice samples) because the .DIG
+couldn't grow, so wholesale replacement of an oversized JP bank meant
+truncation. Now that DigArchive grows freely, wholesale JP banks fit
+intact — and since SCEI_BANK_MAP was built by hash-matching shared
+SFX, those SFX samples are byte-identical between USA and JP banks.
+Wholesale-JP therefore preserves them automatically, with no surgery.
 """
 
 import struct
-import os
-import shutil
-import subprocess
-import tempfile
 
 from .constants import SECTOR, SCEI_BANK_MAP, USA_TABLE_OFFSET, JP_TABLE_OFFSET, TABLE_ENTRY_COUNT
 from .iso import find_file_in_iso
 
-from racjin import compress as racjin_compress, decompress as racjin_decompress
-
 
 # =============================================================================
-# ADPCM Resampling (psxavenc pipeline)
+# CDDATA.DIG Archive
 # =============================================================================
 
-def _find_tool(names):
-    """Find a binary from a list of candidate paths."""
-    for p in names:
-        if p and os.path.exists(p):
-            return p
-    w = shutil.which(names[0]) if names else None
-    return w
+class DigArchive:
+    """Racjin's CDDATA.DIG audio archive — a sector-addressed mini-filesystem.
 
+    Layout: 16-byte TOC entries packed at offset 0, followed by entry data
+    at sector-aligned offsets *within this archive* (not within the ISO).
+    Each TOC entry is [sector:u32, comp_size:u32, flags:u32, decomp_size:u32].
 
-def _fit_sample_psxavenc(jp_adpcm, jp_rate, target_bytes):
-    """Re-encode a JP ADPCM sample to fit in a target byte budget.
-
-    Uses vgmstream to decode, ffmpeg to resample, and psxavenc to re-encode.
-    Returns (resampled_adpcm_bytes, target_rate) tuple, or None on failure.
+    Sector arithmetic stays inside this class — callers operate on entry
+    indices and bytes.
     """
-    psxavenc = _find_tool(['/tmp/psxavenc/build/psxavenc', 'psxavenc'])
-    vgmstream = _find_tool(['/opt/homebrew/bin/vgmstream-cli', '/usr/local/bin/vgmstream-cli', 'vgmstream-cli'])
-    ffmpeg = _find_tool(['/opt/homebrew/bin/ffmpeg', '/usr/local/bin/ffmpeg', 'ffmpeg'])
 
-    if not psxavenc or not vgmstream or not ffmpeg:
-        return None
+    def __init__(self, data):
+        self.buf = bytearray(data)
+        # Next free sector for appended (grown) entries.
+        self._next_sector = (len(data) + SECTOR - 1) // SECTOR
 
-    target_blocks = target_bytes // 16
-    target_samples = target_blocks * 28
-    duration = (len(jp_adpcm) / 16 * 28) / jp_rate if jp_rate > 0 else 0
-    if duration <= 0:
-        return None
-    target_rate = max(4000, min(int(target_samples / duration), jp_rate))
+    def read_entry(self, idx):
+        """Read entry idx. Returns (comp_bytes, decomp_size) or None if empty."""
+        toc = idx * 16
+        if toc + 16 > len(self.buf):
+            return None
+        sec, comp_sz, _, decomp_sz = struct.unpack('<IIII', self.buf[toc:toc + 16])
+        if sec == 0 or comp_sz == 0:
+            return None
+        off = sec * SECTOR
+        return bytes(self.buf[off:off + comp_sz]), decomp_sz
 
-    try:
-        with tempfile.TemporaryDirectory() as tmp:
-            adpcm_path = os.path.join(tmp, 'in.adpcm')
-            with open(adpcm_path, 'wb') as f:
-                f.write(jp_adpcm)
-            with open(adpcm_path + '.txth', 'w') as f:
-                f.write(f'codec = PSX\nchannels = 1\nsample_rate = {jp_rate}\nnum_samples = data_size\n')
+    def slot_size(self, idx):
+        """Original compressed size of entry idx (its in-place capacity)."""
+        toc = idx * 16
+        return struct.unpack('<I', self.buf[toc + 4:toc + 8])[0]
 
-            wav_path = os.path.join(tmp, 'decoded.wav')
-            subprocess.run([vgmstream, '-o', wav_path, adpcm_path], capture_output=True, timeout=30)
-            if not os.path.exists(wav_path):
-                return None
+    def write_entry(self, idx, comp, decomp_size):
+        """Replace entry idx. Writes in-place if it fits the original slot,
+        otherwise appends at end-of-archive and re-points the TOC sector."""
+        toc = idx * 16
+        sec, slot = struct.unpack('<II', self.buf[toc:toc + 8])
 
-            resampled_path = os.path.join(tmp, 'resampled.wav')
-            subprocess.run([ffmpeg, '-y', '-i', wav_path, '-ar', str(target_rate), '-ac', '1',
-                            resampled_path], capture_output=True, timeout=30)
-            if not os.path.exists(resampled_path):
-                return None
+        if len(comp) <= slot:
+            off = sec * SECTOR
+            self.buf[off:off + len(comp)] = comp
+            self.buf[off + len(comp):off + slot] = b'\x00' * (slot - len(comp))
+        else:
+            sec = self._next_sector
+            new_off = sec * SECTOR
+            if new_off > len(self.buf):
+                self.buf.extend(b'\x00' * (new_off - len(self.buf)))
+            self.buf.extend(comp)
+            pad = (SECTOR - (len(comp) % SECTOR)) % SECTOR
+            if pad:
+                self.buf.extend(b'\x00' * pad)
+            self._next_sector = sec + (len(comp) + SECTOR - 1) // SECTOR
 
-            vag_path = os.path.join(tmp, 'out.vag')
-            subprocess.run([psxavenc, '-t', 'vag', '-f', str(target_rate),
-                            resampled_path, vag_path], capture_output=True, timeout=30)
-            if not os.path.exists(vag_path):
-                return None
+        struct.pack_into('<I', self.buf, toc, sec)
+        struct.pack_into('<I', self.buf, toc + 4, len(comp))
+        struct.pack_into('<I', self.buf, toc + 12, decomp_size)
 
-            with open(vag_path, 'rb') as f:
-                vag = f.read()
-            result = bytearray(vag[48:])  # strip VAG header
-            if len(result) > target_bytes:
-                result = result[:target_bytes]
-
-            # Fix ADPCM flags: psxavenc omits END/LOOP markers that
-            # the PS2 SPU2 needs. Without END, the voice reads past
-            # the sample boundary, corrupting audio over time.
-            if len(result) >= 16:
-                result[1] = 0x06  # first block: LOOP_START + LOOP
-                last_block = len(result) - 16
-                result[last_block + 1] = 0x01  # last block: END
-            result = bytes(result)
-            return result, target_rate
-    except Exception:
-        return None
-
-
-# =============================================================================
-# SCEI Sound Bank Parsing
-# =============================================================================
-
-def _parse_scei_samples(bank):
-    """Parse an SCEI sound bank and return per-sample info.
-
-    SCEI banks contain: SCEIVers (version), SCEIVagi (sample table),
-    SCEISets (instrument sets), and audio data. The Vagi chunk holds
-    per-sample metadata: cumulative BD offsets and sample rates.
-
-    Args:
-        bank: Raw bytes of the SCEI sound bank.
-
-    Returns:
-        List of (abs_offset, size, sample_rate) tuples, or None if not SCEI.
-    """
-    # SCEI tags are stored as LE uint32 pairs
-    scei_vagi = struct.pack('<II', 0x53434549, 0x56616769)
-    pos = bank.find(scei_vagi)
-    if pos < 0:
-        return None
-
-    # Read Vagi chunk: [8-byte tag] [4-byte size] [data...]
-    vagi_sz = struct.unpack('<I', bank[pos + 8:pos + 12])[0]
-    vagi = bank[pos + 12:pos + 12 + vagi_sz]
-
-    # Audio data base offset from container header
-    audio_base = struct.unpack('<I', bank[28:32])[0]
-
-    # Parse: [sample_count:4] [BD offsets: (count+1)*4] [padding] [params: count*8]
-    sc = struct.unpack('<I', vagi[0:4])[0]
-
-    # Find where per-sample parameters start (after BD offset table + padding)
-    param_off = 4 + (sc + 1) * 4
-    if param_off % 4 != 0:
-        param_off += 4 - (param_off % 4)
-    while param_off < len(vagi) and struct.unpack('<I', vagi[param_off:param_off + 4])[0] == 0:
-        param_off += 4
-
-    # Read per-sample params: [rate:u16] [flags:u16] [cumulative_offset:u32]
-    # rate_offset is the absolute byte offset of the rate field in the bank,
-    # needed to patch the rate when resampling.
-    vagi_abs = pos + 12  # absolute offset of vagi data within bank
-    samples = []
-    prev_cum = 0
-    for i in range(sc):
-        p = param_off + i * 8
-        if p + 8 > len(vagi):
-            break
-        rate = struct.unpack('<H', vagi[p:p + 2])[0]
-        cum = struct.unpack('<I', vagi[p + 4:p + 8])[0]
-        sz = cum - prev_cum
-        rate_offset = vagi_abs + p  # absolute offset of rate u16 in bank
-        samples.append((audio_base + prev_cum, sz, rate if rate > 0 else 44100, rate_offset))
-        prev_cum = cum
-
-    return samples
-
-
-def _patch_scei_bank(usa_bank, jp_bank):
-    """Replace voice samples in an SCEI bank while preserving SFX.
-
-    Compares each sample by MD5 hash: identical = shared SFX (skip),
-    different = voice content (replace if JP fits in USA slot).
-    The bank structure and total size remain unchanged.
-
-    Args:
-        usa_bank: Raw bytes of the USA SCEI sound bank.
-        jp_bank: Raw bytes of the JP SCEI sound bank.
-
-    Returns:
-        Patched bank bytes, or None if no samples were replaced.
-    """
-    usa_s = _parse_scei_samples(usa_bank)
-    jp_s = _parse_scei_samples(jp_bank)
-    if not usa_s or not jp_s:
-        return None
-
-    # Detect index offset when JP has more samples than USA.
-    # JP may have leading SFX samples that USA's bank omits.
-    jp_offset = 0
-    if len(jp_s) > len(usa_s):
-        best_shared = sum(1 for i in range(min(len(usa_s), len(jp_s)))
-                          if usa_bank[usa_s[i][0]:usa_s[i][0] + usa_s[i][1]] ==
-                          jp_bank[jp_s[i][0]:jp_s[i][0] + jp_s[i][1]])
-        for k in range(1, len(jp_s) - len(usa_s) + 1):
-            shared = sum(1 for i in range(len(usa_s))
-                         if i + k < len(jp_s) and
-                         usa_bank[usa_s[i][0]:usa_s[i][0] + usa_s[i][1]] ==
-                         jp_bank[jp_s[i + k][0]:jp_s[i + k][0] + jp_s[i + k][1]])
-            if shared > best_shared:
-                best_shared = shared
-                jp_offset = k
-        # When no shared samples at any offset, default to aligning voice tails
-        if best_shared == 0:
-            jp_offset = len(jp_s) - len(usa_s)
-
-    out = bytearray(usa_bank)
-    replaced = 0
-
-    for i, (u_off, u_sz, u_rate, u_rate_off) in enumerate(usa_s):
-        j = i + jp_offset
-        if j >= len(jp_s):
-            break
-        j_off, j_sz, j_rate, _ = jp_s[j]
-
-        # Skip identical samples (shared SFX — same hash)
-        if usa_bank[u_off:u_off + u_sz] == jp_bank[j_off:j_off + j_sz]:
-            continue
-
-        # Replace voice sample if JP fits in the USA slot
-        if j_sz <= u_sz:
-            out[u_off:u_off + j_sz] = jp_bank[j_off:j_off + j_sz]
-            if j_sz < u_sz:
-                out[u_off + j_sz:u_off + u_sz] = b'\x00' * (u_sz - j_sz)
-            # Update rate in Vagi params to match JP sample rate
-            struct.pack_into('<H', out, u_rate_off, j_rate)
-            replaced += 1
-            continue
-
-        # JP sample too large — resample to fit using psxavenc
-        result = _fit_sample_psxavenc(jp_bank[j_off:j_off + j_sz], j_rate, u_sz)
-        if result:
-            fitted, fitted_rate = result
-            out[u_off:u_off + len(fitted)] = fitted
-            if len(fitted) < u_sz:
-                out[u_off + len(fitted):u_off + u_sz] = b'\x00' * (u_sz - len(fitted))
-            # Update rate in Vagi params to match resampled rate
-            struct.pack_into('<H', out, u_rate_off, fitted_rate)
-            replaced += 1
-
-    return bytes(out) if replaced > 0 else None
-
-
-# =============================================================================
-# CDDATA TOC Helpers
-# =============================================================================
-
-def _write_cddata_entry(out, data_offset, data, slot_size, toc_offset, comp_size, decomp_size):
-    """Write data into a CDDATA slot and update its TOC entry.
-
-    Args:
-        out: Mutable bytearray of the full CDDATA.DIG.
-        data_offset: Byte offset where data should be written.
-        data: The data bytes to write.
-        slot_size: Total available slot size (zero-pads remainder).
-        toc_offset: Byte offset of this entry's TOC record.
-        comp_size: New compressed size for the TOC.
-        decomp_size: New decompressed size for the TOC.
-    """
-    out[data_offset:data_offset + len(data)] = data
-    out[data_offset + len(data):data_offset + slot_size] = b'\x00' * (slot_size - len(data))
-    struct.pack_into('<I', out, toc_offset + 4, comp_size)
-    struct.pack_into('<I', out, toc_offset + 12, decomp_size)
+    def to_bytes(self):
+        return bytes(self.buf)
 
 
 # =============================================================================
@@ -314,83 +148,35 @@ def build_mapping(usa_iso, jp_iso):
 # =============================================================================
 
 def patch_cddata(usa_dig, jp_dig, mapping):
-    """Patch CDDATA.DIG by replacing USA entries with JP equivalents.
+    """Patch CDDATA.DIG by replacing USA entries with their JP equivalents.
 
-    Processing order per entry:
-    1. Skip if USA and JP data are byte-identical (shared content)
-    2. Direct copy if JP compressed data fits in USA slot
-    3. Racjin recompress if JP data is larger but compressible
-    4. SCEI per-sample replacement for sound banks
-    5. Keep USA version if nothing works (never truncate/corrupt)
+    For each (usa_entry, jp_entry) pair in the mapping: skip if already
+    byte-identical, otherwise wholesale-replace USA's entry with JP's.
+    DigArchive grows the archive when the JP entry doesn't fit the
+    original USA slot.
 
-    Args:
-        usa_dig: Full bytes of USA CDDATA.DIG.
-        jp_dig: Full bytes of JP CDDATA.DIG.
-        mapping: Dict mapping USA entry indices to JP entry indices.
-
-    Returns:
-        Tuple of (patched_bytes, replaced_count, skipped_identical, skipped_nofit).
+    Returns (patched_bytes, replaced_count, skipped_identical, grown_count).
     """
-    out = bytearray(usa_dig)
-    replaced = skipped_identical = skipped_nofit = 0
-    scei_vagi_marker = struct.pack('<II', 0x53434549, 0x56616769)
+    archive = DigArchive(usa_dig)
+    jp_archive = DigArchive(jp_dig)
+    replaced = skipped_identical = grown = 0
 
     for usa_entry, jp_entry in sorted(mapping.items()):
-        # Read USA TOC: [sector, comp_size, flags, decomp_size]
-        usa_toc = usa_entry * 16
-        if usa_toc + 16 > len(out):
-            continue
-        usa_sector, usa_comp_size = struct.unpack('<II', out[usa_toc:usa_toc + 8])
-        if usa_sector == 0 or usa_comp_size == 0:
+        usa = archive.read_entry(usa_entry)
+        jp = jp_archive.read_entry(jp_entry)
+        if usa is None or jp is None:
             continue
 
-        # Read JP TOC
-        jp_toc = jp_entry * 16
-        if jp_toc + 16 > len(jp_dig):
-            continue
-        jp_sector, jp_comp_size, _, jp_decomp_size = struct.unpack('<IIII', jp_dig[jp_toc:jp_toc + 16])
-        if jp_sector == 0 or jp_comp_size == 0:
-            continue
+        usa_comp, _ = usa
+        jp_comp, jp_decomp = jp
 
-        jp_raw = jp_dig[jp_sector * SECTOR:jp_sector * SECTOR + jp_comp_size]
-        usa_raw = out[usa_sector * SECTOR:usa_sector * SECTOR + usa_comp_size]
-        slot_size = usa_comp_size
-        data_offset = usa_sector * SECTOR
-
-        # 1. Skip identical entries (shared SFX/music)
-        if jp_raw == usa_raw:
+        if usa_comp == jp_comp:
             skipped_identical += 1
             continue
 
-        # 2. Direct replacement if JP fits
-        if len(jp_raw) <= slot_size:
-            _write_cddata_entry(out, data_offset, jp_raw, slot_size, usa_toc, len(jp_raw), jp_decomp_size)
-            replaced += 1
-            continue
+        if len(jp_comp) > archive.slot_size(usa_entry):
+            grown += 1
+        archive.write_entry(usa_entry, jp_comp, jp_decomp)
+        replaced += 1
 
-        # 3. Try Racjin recompression
-        if jp_comp_size != jp_decomp_size:
-            try:
-                jp_decompressed = racjin_decompress(jp_raw, jp_decomp_size)
-                recompressed = racjin_compress(jp_decompressed)
-                best = recompressed if len(recompressed) < len(jp_decompressed) else bytes(jp_decompressed)
-                if len(best) <= slot_size:
-                    _write_cddata_entry(out, data_offset, best, slot_size, usa_toc,
-                                        len(best), len(jp_decompressed))
-                    replaced += 1
-                    continue
-            except Exception:
-                pass
-
-        # 4. SCEI per-sample replacement (voice only, SFX preserved)
-        if scei_vagi_marker in bytes(usa_raw):
-            patched_bank = _patch_scei_bank(bytes(usa_raw), jp_raw)
-            if patched_bank:
-                out[data_offset:data_offset + len(patched_bank)] = patched_bank
-                replaced += 1
-                continue
-
-        # 5. Can't fit — keep USA version intact
-        skipped_nofit += 1
-
-    return bytes(out), replaced, skipped_identical, skipped_nofit
+    return archive.to_bytes(), replaced, skipped_identical, grown

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -64,9 +64,8 @@ SCEI_BANK_MAP = {
 # =============================================================================
 # DSI Cutscene Names
 # =============================================================================
-# All 18 cutscene DSI files in the game.
-# M000 = opening (uses full JP DSI replacement, different video+audio)
-# M001, M003 = no dialogue (audio-only, no subtitles)
+# 18 cutscene DSI files. M001 has no dialogue and ships without an .ass
+# (rendered with JP audio only). All others get burned subtitles.
 
 DSI_NAMES = [
     'M000', 'M001', 'M002', 'M003', 'M004', 'M005', 'M006', 'M008',

--- a/lib/ffmpeg.py
+++ b/lib/ffmpeg.py
@@ -12,22 +12,15 @@ import subprocess
 
 
 def find_or_build_ffmpeg():
-    """Find an ffmpeg binary with libass support, or build one.
+    """Find an ffmpeg with libass support, or build one from source.
 
-    Search order:
-    1. /tmp/ffmpeg-custom/ffmpeg (previously built)
-    2. /tmp/ffmpeg-7.1.1/ffmpeg (previously built)
-    3. System ffmpeg (if it has libass)
-    4. Homebrew / system paths
-    5. Build from source as last resort
-
-    Returns:
-        Path to ffmpeg binary with libass, or None on failure.
+    Tries the custom build path first (the one this script produced
+    previously), then any ffmpeg on PATH and standard install locations.
+    Each candidate is verified to expose the libass-backed `subtitles`
+    filter; if none qualify, falls through to building from source.
     """
-    # Check common locations
     candidates = [
-        '/tmp/ffmpeg-custom/ffmpeg',
-        '/tmp/ffmpeg-7.1.1/ffmpeg',
+        '/tmp/ffmpeg-build/ffmpeg-7.1.1/ffmpeg',
         shutil.which('ffmpeg'),
         '/opt/homebrew/bin/ffmpeg',
         '/usr/local/bin/ffmpeg',

--- a/lib/iso.py
+++ b/lib/iso.py
@@ -1,8 +1,10 @@
 """
 ISO9660 filesystem helpers.
 
-Provides functions to locate files within a PS2 ISO image and verify
-ISO integrity via MD5 hash checking.
+The ISO is treated as a flat array of 2048-byte sectors. Files are located
+by directory entry, read by slicing the ISO bytes, and written by seeking
+to a sector and updating the directory entry. All sector arithmetic is
+contained in this module — callers operate on file names and byte buffers.
 """
 
 import struct
@@ -15,13 +17,10 @@ from .constants import SECTOR
 def find_file_in_iso(iso_data, filename):
     """Find a file's sector, size, and directory entry offset in an ISO.
 
-    Searches for the filename in the ISO9660 directory entries and returns
-    the file's starting sector, size in bytes, and the byte offset of the
-    directory entry (useful for patching the entry later).
-
-    Args:
-        iso_data: Raw bytes of the entire ISO image.
-        filename: Filename to find (bytes or str). Use ISO format like b'M004.DSI;1'.
+    The search is a raw byte scan for the ISO9660-encoded filename
+    (e.g. b'M025.DSI;1'). It assumes the filename only appears inside its
+    directory record — generally safe for uppercase-ASCII names with the
+    `;1` revision suffix, which don't show up in audio/video payloads.
 
     Returns:
         Tuple of (sector, size, dir_entry_offset) or None if not found.
@@ -30,10 +29,48 @@ def find_file_in_iso(iso_data, filename):
     pos = iso_data.find(search)
     if pos < 0:
         return None
+    # ISO9660 directory record layout: name lives at offset 33; sector
+    # extent (LE+BE u32) at offset 2; size (LE+BE u32) at offset 10.
     entry = pos - 33
     sector = struct.unpack('<I', iso_data[entry + 2:entry + 6])[0]
     size = struct.unpack('<I', iso_data[entry + 10:entry + 14])[0]
     return sector, size, entry
+
+
+def read_file_from_iso(iso_data, filename):
+    """Locate and slice a file's bytes out of the ISO.
+
+    Returns:
+        Tuple of (data, dir_entry_offset) or None if not found. The dir
+        offset is returned so callers can later relocate/resize the file.
+    """
+    info = find_file_in_iso(iso_data, filename)
+    if info is None:
+        return None
+    sector, size, dir_offset = info
+    return iso_data[sector * SECTOR:sector * SECTOR + size], dir_offset
+
+
+def write_file_to_iso(f, dir_offset, sector, data):
+    """Write a file at the given sector, pad to sector boundary, and update
+    its directory entry to match the new sector and size.
+
+    Args:
+        f: File object opened in r+b mode.
+        dir_offset: Byte offset of the file's directory entry in the ISO.
+        sector: Sector at which to write the file's contents.
+        data: File contents.
+
+    Returns:
+        The next free sector after this file (sector + ceil(len(data)/SECTOR)).
+    """
+    f.seek(sector * SECTOR)
+    f.write(data)
+    pad = (SECTOR - (len(data) % SECTOR)) % SECTOR
+    if pad:
+        f.write(b'\x00' * pad)
+    update_dir_entry(f, dir_offset, sector, len(data))
+    return sector + (len(data) + SECTOR - 1) // SECTOR
 
 
 def update_dir_entry(f, entry_offset, sector, size):

--- a/lib/video.py
+++ b/lib/video.py
@@ -15,6 +15,10 @@ import tempfile
 
 from dsi_muxer import DSI
 
+# libass's `fontsdir=` ffmpeg option accepts only ONE directory; we pick
+# the first that exists. User dirs (~/Library/Fonts, /usr/local/share/fonts)
+# come first so user-installed subtitle fonts beat system-bundled ones with
+# the same name.
 _FONT_DIRS = [
     os.path.expanduser('~/Library/Fonts'),
     '/Library/Fonts',
@@ -26,7 +30,6 @@ _FONT_DIRS = [
 
 
 def _find_fontsdir():
-    """Find a directory containing fonts for subtitle rendering."""
     for d in _FONT_DIRS:
         if os.path.isdir(d):
             return d
@@ -40,20 +43,14 @@ def _find_fontsdir():
 def encode_subtitled_video(ffmpeg_bin, m2v_path, ass_path, output_path):
     """Encode video with burned ASS subtitles as PS2-compatible MPEG-2.
 
-    Uses high-quality CBR encoding at 7500k — no size constraint since
-    DSI block count is auto-calculated from content size.
+    The flag set below was tuned to match the original game's MPEG-2
+    parameters (resolution 512x448, 7:6 SAR, NTSC 30000/1001, GOP 16
+    with 2 B-frames, fixed 7500k CBR). PS2 hardware is picky — past
+    incidents traced to bitrate or GOP changes caused choppy playback
+    or SPU2 corruption. Don't reshape these without testing on real PS2.
 
-    Args:
-        ffmpeg_bin: Path to ffmpeg binary.
-        m2v_path: Input MPEG-2 video.
-        ass_path: ASS subtitle file to burn.
-        output_path: Where to write the encoded .m2v.
-
-    Returns:
-        True on success, False on failure.
-
-    Raises:
-        RuntimeError: If libass reports missing fonts.
+    Returns True on success, False on failure. Raises RuntimeError if
+    libass reports missing fonts.
     """
     ass_filter = f'ass={ass_path}'
     fontsdir = _find_fontsdir()
@@ -63,9 +60,14 @@ def encode_subtitled_video(ffmpeg_bin, m2v_path, ass_path, output_path):
     r = subprocess.run([ffmpeg_bin, '-y', '-i', m2v_path,
         '-vf', f'{ass_filter},format=yuv420p',
         '-c:v', 'mpeg2video',
+        # CBR 7500k — DSI block count is auto-sized so no upper bound
+        # is needed, but PS2 expects a stable bitrate per block.
         '-b:v', '7500k', '-minrate', '7500k', '-maxrate', '7500k',
-        '-bufsize', '1835008', '-qmin', '1', '-qmax', '12',
+        '-bufsize', '1835008',  # 224 KB VBV — original game value
+        '-qmin', '1', '-qmax', '12',
         '-s', '512x448', '-sar', '7:6', '-r', '30000/1001',
+        # GOP=16 with 2 B-frames matches the original encoder layout
+        # the PS2's hardware decoder is tuned for.
         '-g', '16', '-bf', '2', '-b_strategy', '0',
         '-mpv_flags', '+strict_gop', '-dc', '9',
         '-intra_vlc', '1', '-non_linear_quant', '1',
@@ -86,7 +88,9 @@ def encode_subtitled_video(ffmpeg_bin, m2v_path, ass_path, output_path):
     if not os.path.exists(output_path) or os.path.getsize(output_path) == 0:
         return False
 
-    # Ensure end-of-sequence marker exists
+    # The PS2's MPEG-2 decoder hangs at the end of the stream unless it
+    # sees an end-of-sequence start code (00 00 01 B7). ffmpeg sometimes
+    # omits it; append it ourselves after stripping any trailing zero pad.
     with open(output_path, 'rb') as f:
         vid = bytearray(f.read())
     if vid.rfind(b'\x00\x00\x01\xb7') < 0:

--- a/patch.py
+++ b/patch.py
@@ -28,10 +28,11 @@ import subprocess
 import tempfile
 
 from lib.constants import (
-    DSI_BLOCK_SIZE, SECTOR, EXPECTED_HASHES,
-    DSI_NAMES, SUBS_DIR,
+    SECTOR, EXPECTED_HASHES, DSI_NAMES, SUBS_DIR,
 )
-from lib.iso import find_file_in_iso, update_dir_entry, verify_iso
+from lib.iso import (
+    find_file_in_iso, read_file_from_iso, write_file_to_iso, verify_iso,
+)
 from lib.cddata import build_mapping, patch_cddata
 from lib.video import build_subtitled_dsi, dump_mkv
 from lib.ffmpeg import find_or_build_ffmpeg
@@ -43,12 +44,13 @@ from dsi_muxer import DSI
 # =============================================================================
 
 def find_xdelta():
-    """Find xdelta3 binary."""
-    xdelta = shutil.which('xdelta3') or shutil.which('xdelta')
+    """Find xdelta3 binary on PATH or in standard Homebrew/system locations."""
+    if found := shutil.which('xdelta3') or shutil.which('xdelta'):
+        return found
     for p in ['/opt/homebrew/bin/xdelta3', '/usr/local/bin/xdelta3']:
-        if not xdelta and os.path.exists(p):
-            xdelta = p
-    return xdelta
+        if os.path.exists(p):
+            return p
+    return None
 
 
 def do_xdelta(args):
@@ -95,11 +97,7 @@ def generate_xdelta(usa_iso_path, out_iso_path):
 # =============================================================================
 
 def do_audio(usa_iso_path, jp_iso_path, out_iso_path):
-    """Audio-only undub: full JP DSIs (no size constraint) + CDDATA patching.
-
-    Writes JP cutscenes sequentially into the ISO, relocating files and
-    updating ISO9660 directory entries. No bitrate-constrained encoding.
-    """
+    """Audio-only undub: JP CDDATA + JP DSIs, all relocated at end of ISO."""
     print("Reading ISOs...")
     with open(usa_iso_path, 'rb') as f:
         usa_iso = f.read()
@@ -108,67 +106,40 @@ def do_audio(usa_iso_path, jp_iso_path, out_iso_path):
 
     shutil.copy2(usa_iso_path, out_iso_path)
 
-    # --- Step 1: Patch CDDATA.DIG (in-place, same size) ---
     mapping = build_mapping(usa_iso, jp_iso)
     print(f"  Mapping: {len(mapping)} entries")
 
     print("Patching CDDATA.DIG...")
+    usa_dig, cddata_dir = read_file_from_iso(usa_iso, b'CDDATA.DIG;1')
+    jp_dig, _ = read_file_from_iso(jp_iso, b'CDDATA.DIG;1')
+    patched_dig, replaced, skipped_same, grown = patch_cddata(usa_dig, jp_dig, mapping)
+    print(f"  Replaced: {replaced}, Skipped (identical): {skipped_same}, Grown: {grown}")
+
+    # Relocate CDDATA + DSIs + DATA0 to end of ISO. Reusing the original
+    # CDDATA region as the staging area for the new layout.
     usa_cddata_info = find_file_in_iso(usa_iso, b'CDDATA.DIG;1')
-    jp_cddata_info = find_file_in_iso(jp_iso, b'CDDATA.DIG;1')
-    usa_dig = usa_iso[usa_cddata_info[0] * SECTOR:usa_cddata_info[0] * SECTOR + usa_cddata_info[1]]
-    jp_dig = jp_iso[jp_cddata_info[0] * SECTOR:jp_cddata_info[0] * SECTOR + jp_cddata_info[1]]
-
-    patched_dig, replaced, skipped_same, skipped_nofit = patch_cddata(usa_dig, jp_dig, mapping)
-    print(f"  Replaced: {replaced}, Skipped (identical): {skipped_same}, Skipped (too large): {skipped_nofit}")
+    write_sector = usa_cddata_info[0]
 
     with open(out_iso_path, 'r+b') as f:
-        f.seek(usa_cddata_info[0] * SECTOR)
-        f.write(patched_dig[:usa_cddata_info[1]])
+        write_sector = write_file_to_iso(f, cddata_dir, write_sector, patched_dig)
 
-    # --- Step 2: Write JP DSIs sequentially ---
-    print("Writing JP cutscenes...")
-
-    # DSIs start right after CDDATA.DIG
-    cddata_end = usa_cddata_info[0] + (usa_cddata_info[1] + SECTOR - 1) // SECTOR
-    write_sector = cddata_end
-
-    with open(out_iso_path, 'r+b') as f:
+        print("Writing JP cutscenes...")
         for name in DSI_NAMES:
+            jp = read_file_from_iso(jp_iso, f'{name}.DSI;1'.encode())
             usa_info = find_file_in_iso(usa_iso, f'{name}.DSI;1'.encode())
-            jp_info = find_file_in_iso(jp_iso, f'{name}.DSI;1'.encode())
-            if not usa_info or not jp_info:
+            if jp is None or usa_info is None:
                 continue
+            jp_dsi, _ = jp
+            print(f"  {name}: {len(jp_dsi) / 1024 / 1024:.1f} MB")
+            write_sector = write_file_to_iso(f, usa_info[2], write_sector, jp_dsi)
 
-            jp_sec, jp_sz, _ = jp_info
-            jp_dsi = jp_iso[jp_sec * SECTOR:jp_sec * SECTOR + jp_sz]
+        data0 = read_file_from_iso(usa_iso, b'DATA0')
+        if data0 is not None:
+            data0_content, data0_dir = data0
+            write_sector = write_file_to_iso(f, data0_dir, write_sector, data0_content)
 
-            f.seek(write_sector * SECTOR)
-            f.write(jp_dsi)
-            pad = (SECTOR - (jp_sz % SECTOR)) % SECTOR
-            if pad:
-                f.write(b'\x00' * pad)
-
-            update_dir_entry(f, usa_info[2], write_sector, jp_sz)
-
-            file_sectors = (jp_sz + SECTOR - 1) // SECTOR
-            print(f"  {name}: {jp_sz / 1024 / 1024:.1f} MB")
-            write_sector += file_sectors
-
-        # DATA0 (runtime scratchpad) — relocate after last DSI
-        data0_info = find_file_in_iso(usa_iso, b'DATA0')
-        if data0_info:
-            data0_sec, data0_sz, data0_dir = data0_info
-            data0_content = usa_iso[data0_sec * SECTOR:data0_sec * SECTOR + data0_sz]
-            f.seek(write_sector * SECTOR)
-            f.write(data0_content)
-            update_dir_entry(f, data0_dir, write_sector, data0_sz)
-            write_sector += (data0_sz + SECTOR - 1) // SECTOR
-
-        # Truncate ISO to actual size
         f.seek(write_sector * SECTOR)
         f.truncate()
-
-    return usa_iso, jp_iso
 
 
 # =============================================================================
@@ -176,14 +147,7 @@ def do_audio(usa_iso_path, jp_iso_path, out_iso_path):
 # =============================================================================
 
 def do_full(usa_iso_path, jp_iso_path, out_iso_path, dump_mkv_dir=None):
-    """Full pipeline: JP audio + burned English subtitles on all cutscenes.
-
-    For each cutscene:
-    1. Take JP DSI (video + audio)
-    2. Burn English subtitles onto JP video
-    3. Remux with dsi-muxer (auto block count, no size constraint)
-    4. Write sequentially into ISO, relocating files as needed
-    """
+    """Full pipeline: JP audio + burned English subtitles on all cutscenes."""
     print("Reading ISOs...")
     with open(usa_iso_path, 'rb') as f:
         usa_iso = f.read()
@@ -192,24 +156,15 @@ def do_full(usa_iso_path, jp_iso_path, out_iso_path, dump_mkv_dir=None):
 
     shutil.copy2(usa_iso_path, out_iso_path)
 
-    # --- Step 1: Patch CDDATA.DIG ---
     mapping = build_mapping(usa_iso, jp_iso)
     print(f"  Mapping: {len(mapping)} entries")
 
     print("Patching CDDATA.DIG...")
-    usa_cddata_info = find_file_in_iso(usa_iso, b'CDDATA.DIG;1')
-    jp_cddata_info = find_file_in_iso(jp_iso, b'CDDATA.DIG;1')
-    usa_dig = usa_iso[usa_cddata_info[0] * SECTOR:usa_cddata_info[0] * SECTOR + usa_cddata_info[1]]
-    jp_dig = jp_iso[jp_cddata_info[0] * SECTOR:jp_cddata_info[0] * SECTOR + jp_cddata_info[1]]
+    usa_dig, cddata_dir = read_file_from_iso(usa_iso, b'CDDATA.DIG;1')
+    jp_dig, _ = read_file_from_iso(jp_iso, b'CDDATA.DIG;1')
+    patched_dig, replaced, skipped_same, grown = patch_cddata(usa_dig, jp_dig, mapping)
+    print(f"  Replaced: {replaced}, Skipped (identical): {skipped_same}, Grown: {grown}")
 
-    patched_dig, replaced, skipped_same, skipped_nofit = patch_cddata(usa_dig, jp_dig, mapping)
-    print(f"  Replaced: {replaced}, Skipped (identical): {skipped_same}, Skipped (too large): {skipped_nofit}")
-
-    with open(out_iso_path, 'r+b') as f:
-        f.seek(usa_cddata_info[0] * SECTOR)
-        f.write(patched_dig[:usa_cddata_info[1]])
-
-    # --- Step 2: Build subtitled DSIs and write sequentially ---
     ffmpeg_bin = find_or_build_ffmpeg()
     if not ffmpeg_bin:
         print("WARNING: Could not get ffmpeg with libass — falling back to audio-only")
@@ -217,25 +172,27 @@ def do_full(usa_iso_path, jp_iso_path, out_iso_path, dump_mkv_dir=None):
     if dump_mkv_dir:
         os.makedirs(dump_mkv_dir, exist_ok=True)
 
-    print("Writing cutscenes...")
-    cddata_end = usa_cddata_info[0] + (usa_cddata_info[1] + SECTOR - 1) // SECTOR
-    write_sector = cddata_end
+    usa_cddata_info = find_file_in_iso(usa_iso, b'CDDATA.DIG;1')
+    write_sector = usa_cddata_info[0]
 
     with open(out_iso_path, 'r+b') as f:
+        write_sector = write_file_to_iso(f, cddata_dir, write_sector, patched_dig)
+
+        print("Writing cutscenes...")
         for name in DSI_NAMES:
+            jp = read_file_from_iso(jp_iso, f'{name}.DSI;1'.encode())
             usa_info = find_file_in_iso(usa_iso, f'{name}.DSI;1'.encode())
-            jp_info = find_file_in_iso(jp_iso, f'{name}.DSI;1'.encode())
-            if not usa_info or not jp_info:
+            if jp is None or usa_info is None:
                 continue
+            jp_dsi_bytes, _ = jp
 
-            jp_sec, jp_sz, _ = jp_info
-            jp_dsi_bytes = jp_iso[jp_sec * SECTOR:jp_sec * SECTOR + jp_sz]
-
-            # Try to build subtitled DSI
             ass_path = os.path.join(SUBS_DIR, f'{name}.ass')
-            has_subs = (ffmpeg_bin and os.path.exists(ass_path) and
-                        'Dialogue:' in open(ass_path).read())
+            has_subs = False
+            if ffmpeg_bin and os.path.exists(ass_path):
+                with open(ass_path) as af:
+                    has_subs = 'Dialogue:' in af.read()
 
+            sub_dsi = None
             if has_subs:
                 sub_dsi = build_subtitled_dsi(ffmpeg_bin, jp_dsi_bytes, ass_path)
 
@@ -250,33 +207,16 @@ def do_full(usa_iso_path, jp_iso_path, out_iso_path, dump_mkv_dir=None):
                         dump_mkv(ffmpeg_bin, m2v_path, src.extract_audio(), mkv_path)
                         if os.path.exists(mkv_path):
                             print(f"    -> {mkv_path}")
-            else:
-                sub_dsi = None
 
             dsi_data = sub_dsi if sub_dsi is not None else jp_dsi_bytes
             label = "subtitled" if sub_dsi is not None else "JP audio"
-
-            f.seek(write_sector * SECTOR)
-            f.write(dsi_data)
-            pad = (SECTOR - (len(dsi_data) % SECTOR)) % SECTOR
-            if pad:
-                f.write(b'\x00' * pad)
-
-            update_dir_entry(f, usa_info[2], write_sector, len(dsi_data))
-
-            file_sectors = (len(dsi_data) + SECTOR - 1) // SECTOR
             print(f"  {name}: {len(dsi_data) / 1024 / 1024:.1f} MB ({label})")
-            write_sector += file_sectors
+            write_sector = write_file_to_iso(f, usa_info[2], write_sector, dsi_data)
 
-        # DATA0
-        data0_info = find_file_in_iso(usa_iso, b'DATA0')
-        if data0_info:
-            data0_sec, data0_sz, data0_dir = data0_info
-            data0_content = usa_iso[data0_sec * SECTOR:data0_sec * SECTOR + data0_sz]
-            f.seek(write_sector * SECTOR)
-            f.write(data0_content)
-            update_dir_entry(f, data0_dir, write_sector, data0_sz)
-            write_sector += (data0_sz + SECTOR - 1) // SECTOR
+        data0 = read_file_from_iso(usa_iso, b'DATA0')
+        if data0 is not None:
+            data0_content, data0_dir = data0
+            write_sector = write_file_to_iso(f, data0_dir, write_sector, data0_content)
 
         f.seek(write_sector * SECTOR)
         f.truncate()
@@ -337,7 +277,11 @@ def main():
         else:
             do_audio(usa_path, jp_path, out_path)
 
-        # Update PVD volume size — required for real PS2 hardware
+        # Update the Primary Volume Descriptor's volume-space-size field.
+        # The PVD lives at sector 16; the field is at offset 80, stored as
+        # an LE u32 followed by a BE u32. PCSX2 ignores it but real PS2
+        # hardware refuses to load discs whose PVD size disagrees with the
+        # actual image length.
         final = os.path.getsize(out_path)
         final_sectors = (final + SECTOR - 1) // SECTOR
         with open(out_path, 'r+b') as f:


### PR DESCRIPTION
Closes #4.

## Summary

- `CDDATA.DIG` is now relocated like any other file: written at end of ISO with its ISO9660 directory entry updated to the new sector and size. The fixed-size write was the root cause of every workaround in `lib/cddata.py`.
- New `DigArchive` class wraps the .DIG buffer and grows it whenever a JP entry doesn't fit the original USA slot — appends at end-of-DIG, repoints the TOC sector.
- New `read_file_from_iso` / `write_file_to_iso` in `lib/iso.py` hide all sector arithmetic and `update_dir_entry` plumbing behind a file-level API. `patch.py` no longer touches sector math directly.
- Wholesale JP replacement at the entry level for every audio entry. The 47 entries that were force-fit through `psxavenc` (lowest ~7 kHz) are now at full original sample rate.

## SCEI banks

The per-sample SCEI surgery from v5.0 is gone. Wholesale replacement preserves shared SFX automatically because `SCEI_BANK_MAP` was built by hash-matching SFX samples that are byte-identical between USA and JP — wholesale-JP places those same bytes in the same logical positions. The bank stays internally consistent (JP `Head`/`Vagi`/`Sset`/`Prog` + JP audio).

A short-lived attempt at proper layer-3 surgery (preserve USA `Prog`, swap voice samples) caused held-tone "horn" artefacts in combat — the `Prog` chunk encodes per-region pitch tuning calibrated for USA's sample rates, so JP audio with USA tuning plays at the wrong pitch. Backed out in favour of wholesale.

## Removed

- `_parse_scei_samples`, `_patch_scei_bank`, `_detect_jp_sample_offset`
- `_fit_sample_psxavenc`, `_find_tool` (psxavenc/vgmstream pipeline)
- `DigArchive.patch_entry_bytes`
- `psxavenc` and `vgmstream` are no longer required to build the patch

`lib/cddata.py` shrank from 413 → 182 lines.

## Stats

| | before | after |
|---|---|---|
| Replaced entries | 43 | 90 |
| Skipped (lossy resample / drop) | 47 | 0 |
| Grown entries | — | 54 |
| Resampled entries | up to 47 | **0** |

## Test plan

- [x] Audio-only build (`patch.py audio`) — 90 replaced, 54 grown, 0 lossy
- [x] Full build (`patch.py full`) — same numbers, subtitled cutscenes intact
- [x] All SCEI banks parse cleanly in the patched DIG (96/96)
- [x] All 18 DSI files have valid pointers
- [x] All 198 mapped CDDATA entries readable
- [x] PCSX2 boot test — no horn / corruption in combat audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)